### PR TITLE
New grasp verification

### DIFF
--- a/src/execute_grasp_action_server.py
+++ b/src/execute_grasp_action_server.py
@@ -191,6 +191,10 @@ class ExecuteGraspServer:
             self.hsr_wrapper.move_eef_by_line((0, 0, 1), -safety_distance)
 
             self.hsr_wrapper.gripper_grasp_hsr(0.5)
+
+            res.verify_grasp = not self.hsr_wrapper.grasp_succesful()
+
+            """
             if not self.hsr_wrapper.grasp_succesful():
                 rospy.logdebug("Execute grasp: Grasp failed")
                 self.moveit_wrapper.detach_all_objects()
@@ -199,7 +203,7 @@ class ExecuteGraspServer:
                 # which potentially invalidates the grasp pose
                 self.server.set_aborted(res)
                 return
-            
+            """
             self.server.set_succeeded(res)
             return
         

--- a/src/object_detector.py
+++ b/src/object_detector.py
@@ -115,8 +115,14 @@ class CallObjectDetectorService:
         server_state = obj_det.get_state()
         
         if server_state != GoalStatus.SUCCEEDED or len(detection_result.class_names) <= 0:
-            rospy.logerr('Object Detector failed to detect objects!')
-            raise rospy.ServiceException
+            rospy.logwarn('Object Detector failed to detect objects!')
+            # Not raising an exception here, as this can happen when the a grasp needs to be verified and all objects were removed from the table
+            res = CallObjectDetectorResponse()
+            res.bb_detections = []
+            res.mask_detections = []
+            res.class_names = []
+            res.class_confidences = []
+            return res
         rospy.loginfo(f'Detected {len(detection_result.class_names)} objects.')
 
         np_rgb = ros_numpy.numpify(req.rgb)

--- a/src/statemachine.py
+++ b/src/statemachine.py
@@ -2,9 +2,9 @@
 import rospy
 import smach
 import smach_ros
-from statemachine_components import get_robot_setup_sm, get_execute_grasp_sm, get_placement_sm, get_find_grasp_sm
+from statemachine_components import get_robot_setup_sm, get_execute_grasp_sm, get_placement_sm, get_find_grasp_sm, get_obj_detection_sm
 from userinput import UserInput
-from robot_control import GoToWaypoint, GoBack, GoToNeutral, CheckTopGrasp
+from robot_control import GoToWaypoint, GoBack, GoToNeutral, CheckTopGrasp, CheckVerifyGrasp, VerifyGrasp, CheckObjectDetection
 from grasp_method_selector import GraspMethodSelector
 from grasping_pipeline_msgs.msg import FindGrasppointAction
 from handover.msg import HandoverAction
@@ -14,46 +14,78 @@ def create_statemachine(do_handover=True):
 
     table_waypoint = GoToWaypoint(0.25, 0.41, 0)
     setup_sm = get_robot_setup_sm(table_waypoint)
+    obj_detection_sm = get_obj_detection_sm()
     find_grasp_sm = get_find_grasp_sm()
     execute_grasp_sm = get_execute_grasp_sm(table_waypoint)
     placement_sm = get_placement_sm()
     with sm:
+        # State machine for robot setup
         smach.StateMachine.add('SETUP', setup_sm, transitions={'setup_succeeded': 'FIND_GRASP_USERINPUT'})
 
+        # States for user input after setup
         map = {'f': ['succeeded', 'find grasp point']}
         smach.StateMachine.add('FIND_GRASP_USERINPUT', UserInput(
-            map), transitions={'succeeded': 'FIND_GRASP'})
+            map), transitions={'succeeded': 'OBJECT_DETECTION'})
+        
+        # State machine for getting the rgb and depth image and calling the object detector
+        # Returns rgb, depth, bb_detections, mask_detections, class_names, class_confidences
+        smach.StateMachine.add('OBJECT_DETECTION', obj_detection_sm, transitions={
+            'succeeded': 'CHECK_OBJECT_DETECTION', 'aborted': 'SETUP', 'failed': 'SETUP'}, 
+            remapping={'rgb':'rgb', 'depth':'depth', 'bb_detections':'bb_detections', 'mask_detections':'mask_detections', 'class_names':'class_names', 'class_confidences':'class_confidences'})
 
+        # State for checking if object detection was successful (TODO: Only temporary solution)
+        # Problem: Object detection is allowed to not detect object when the grasp is getting verified, but not here (table has no more objects on it)
+        smach.StateMachine.add('CHECK_OBJECT_DETECTION', CheckObjectDetection(), transitions={'succeeded': 'FIND_GRASP', 'failed': 'SETUP'})
+
+        # State machine for finding the grasp point
+        # Returns grasp_poses, grasp_object_bb, grasp_object_name
         smach.StateMachine.add('FIND_GRASP', find_grasp_sm, transitions={
             'end_find_grasp': 'EXECUTE_GRASP_USERINPUT', 'failed': 'SETUP'}, 
             remapping={'grasp_poses':'grasp_poses', 'grasp_object_bb':'grasp_object_bb', 'grasp_object_name':'grasp_object_name'})
         
-
+        # States for user input after finding the grasp point
         map = {'g': ['succeeded', 'grasp object'],
                't': ['retry', 'try again']}
         smach.StateMachine.add('EXECUTE_GRASP_USERINPUT', UserInput(
-            map), transitions={'retry': 'FIND_GRASP', 'succeeded': 'EXECUTE_GRASP'})
+            map), transitions={'retry': 'OBJECT_DETECTION', 'succeeded': 'EXECUTE_GRASP'})
         
+        # State machine for executing the grasp
+        # Returns placement_surface_to_wrist, top_grasp, verify_grasp
         smach.StateMachine.add('EXECUTE_GRASP', execute_grasp_sm, transitions={
-            'end_execute_grasp': 'CHECK_TOP_GRASP', 'failed_to_grasp': 'SETUP'})
+            'end_execute_grasp': 'CHECK_VERIFY_GRASP', 'failed_to_grasp': 'SETUP'})
         
+        # States for checking if the grasp needs to be verified (verify_grasp = True) (e.g. the gripper is closed)
+        smach.StateMachine.add('CHECK_VERIFY_GRASP', CheckVerifyGrasp(), transitions={'succeeded': 'CHECK_TOP_GRASP', 'verify_grasp': 'VERIFY_GRASP_OBJECT_DETECTION'})
+
+        smach.StateMachine.add('VERIFY_GRASP_OBJECT_DETECTION', obj_detection_sm, transitions={
+            'succeeded': 'VERIFY_GRASP_COMPARE_OBJECT_NAMES', 'aborted': 'SETUP', 'failed': 'SETUP'}, 
+            remapping={'rgb':'_', 'depth':'_', 'bb_detections':'bb_detections_new', 'mask_detections':'mask_detections_new', 'class_names':'class_names_new', 'class_confidences':'_'})
+
+        smach.StateMachine.add('VERIFY_GRASP_COMPARE_OBJECT_NAMES', VerifyGrasp(), transitions={'succeeded': 'CHECK_TOP_GRASP', 'failed': 'SETUP'})
+        
+        # State for checking if the grasp is a top grasp (top_grasp = True). If the grasp is a top grasp the object is handed over to the user.
         smach.StateMachine.add('CHECK_TOP_GRASP', CheckTopGrasp(), transitions={'top_grasp': 'HANDOVER', 'not_top_grasp': 'AFTER_GRASP_USERINPUT'})
         
+        # States for user input after the grasp
         map = {'p': ['placement', 'place object'],
                'h': ['handover', 'handover object']}
         smach.StateMachine.add('AFTER_GRASP_USERINPUT', UserInput(
             map), transitions={'placement': 'PLACEMENT', 'handover': 'HANDOVER'})
 
+        # State for handing over the object to the user (either because it's a top grasp or the user requested it)
         smach.StateMachine.add('HANDOVER', smach_ros.SimpleActionState('/handover', HandoverAction),
                                 transitions={'succeeded': 'SETUP',
                                              'preempted': 'SETUP',
                                              'aborted': 'SETUP'})
         
+        # State machine for placing the object (only if the user requested it, grasp is not a top grasp)
         smach.StateMachine.add('PLACEMENT', placement_sm, transitions={'end_placement': 'RETREAT_AFTER_PLACEMENT', 'failed_to_place': 'GO_BACK_TO_TABLE'})
         
+        # States for retreating after placing the object
         smach.StateMachine.add('RETREAT_AFTER_PLACEMENT', GoBack(0.2), transitions={'succeeded': 'GO_TO_NEUTRAL_AFTER_PLACEMENT', 'aborted': 'GO_TO_NEUTRAL_AFTER_PLACEMENT'})
         smach.StateMachine.add('GO_TO_NEUTRAL_AFTER_PLACEMENT', GoToNeutral(), transitions={'succeeded': 'SETUP'})
 
+        # States for going back to the table
         smach.StateMachine.add('GO_BACK_TO_TABLE', table_waypoint, transitions={'succeeded': 'HANDOVER', 'aborted': 'GO_BACK_TO_TABLE'})
 
     return sm


### PR DESCRIPTION
The HSR now verifies a successful grasp by first checking the gripper, as before. If the gripper is (nearly) closed, the robot moves to the table waypoint, calls the object detector again, and compares the detected classes.

Check the commits for detailed changes.
**NOTE:** Please review if the approach I used is efficient. Some old code is still commented out, which I’ll remove if we stick with this new version. I was only able to test using the table plane extractor since the HSR couldn’t grasp objects when using poses from gdrnpp and YOLO (thanks to Sasha and MoveIt). I also updated a message in grasping_pipeline_msgs.

Also some side notes: 
1. Maybe we should rename "robot_control.py" because there is a lot more stuff than just robot control stuff inside (or create a second file). Maybe rename it to "smach_states.py"?
2. We should take a look, how we wan't to check if the object detection was successful. My current implementation works but is not the prettiest.
3. In case the statemachine get's updated, we probably need to change the docs